### PR TITLE
REF: use image scala-sbt to build project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 target
 */target
+.ivy2
+.sbt

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8-jre-alpine
+WORKDIR /opt/docker
+ADD --chown=daemon:daemon target/scala-2.12/ /opt/docker
+USER daemon
+ENTRYPOINT ["java", "-jar", "app-assembly-1.jar" ]
+CMD []
+

--- a/build-project.sh
+++ b/build-project.sh
@@ -1,0 +1,5 @@
+#assume docker invocing user has id 1000:1000
+#lets avoid creating host folder .sbt and ivy2 directorys with root:root
+groupadd -g 1000 user
+useradd --no-log-init -r -u 1000 -g 1000 user -d /root
+su user -c "sbt assembly"

--- a/build-project.sh
+++ b/build-project.sh
@@ -1,5 +1,4 @@
-#assume docker invocing user has id 1000:1000
 #lets avoid creating host folder .sbt and ivy2 directorys with root:root
-groupadd -g 1000 user
-useradd --no-log-init -r -u 1000 -g 1000 user -d /root
-su user -c "sbt assembly"
+groupadd -g $HOSTUID usergroup
+useradd --no-log-init -r -u $HOSTUID -g usergroup hostuser -d /root
+su hostuser -c "sbt assembly"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-
 lazy val commonSettings = Seq(
   version := "1",
   organization := "session-segmenter",
@@ -30,16 +29,14 @@ lazy val app = project.dependsOn(common)
         "org.apache.kafka" % "kafka-streams-test-utils" % "2.1.0" % "test"
       )
     },
-    packageName in Docker := "session-segmenter"
-  ).enablePlugins(JavaAppPackaging,DockerPlugin)
+  ).enablePlugins(JavaAppPackaging)
 
 
 lazy val driver = project.dependsOn(common)
   .settings(commonSettings: _*)
-  .settings(packageName in Docker := "session-segmenter-driver")
-  .enablePlugins(JavaAppPackaging,DockerPlugin)
+  .enablePlugins(JavaAppPackaging)
 
 lazy val reader = project.dependsOn(common)
   .settings(commonSettings: _*)
-  .settings(packageName in Docker := "session-segmenter-reader")
-  .enablePlugins(JavaAppPackaging,DockerPlugin)
+  .enablePlugins(JavaAppPackaging)
+

--- a/build.sh
+++ b/build.sh
@@ -3,12 +3,9 @@
 docker run -it --rm -e HOSTUID=$(id -u) -v $(pwd):/root hseeberger/scala-sbt sh ./build-project.sh
 if [[ $? -eq 0 ]]
 then 
-bash -c "cd driver && docker build -t session-segmenter-driver ."
-bash -c "cd driver && docker tag session-segmenter-driver session-segmenter-driver:1"
-bash -c "cd app && docker build -t session-segmenter-app ."
-bash -c "cd driver && docker tag session-segmenter-app session-segmenter-app:1"
-bash -c "cd reader && docker build -t session-segmenter-reader ."
-bash -c "cd driver && docker tag session-segmenter-reader session-segmenter-reader:1"
+bash -c "cd driver && docker build -t session-segmenter-driver:1 ."
+bash -c "cd app && docker build -t session-segmenter:1 ."
+bash -c "cd reader && docker build -t session-segmenter-reader:1 ."
 else
   exit 1
 fi

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,11 @@ docker run -it --rm -e HOSTUID=$(id -u) -v $(pwd):/root hseeberger/scala-sbt sh 
 if [[ $? -eq 0 ]]
 then 
 bash -c "cd driver && docker build -t session-segmenter-driver ."
+bash -c "cd driver && docker tag session-segmenter-driver session-segmenter-driver:1"
 bash -c "cd app && docker build -t session-segmenter-app ."
+bash -c "cd driver && docker tag session-segmenter-app session-segmenter-app:1"
 bash -c "cd reader && docker build -t session-segmenter-reader ."
+bash -c "cd driver && docker tag session-segmenter-reader session-segmenter-reader:1"
 else
   exit 1
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-docker run -it --rm -v $(pwd):/root hseeberger/scala-sbt sh ./build-project.sh
-#docker run -it --rm -v $(pwd):/user hseeberger/scala-sbt cd /user && sbt compile assembly
+docker run -it --rm -e HOSTUID=$(id -u) -v $(pwd):/root hseeberger/scala-sbt sh ./build-project.sh
 if [[ $? -eq 0 ]]
 then 
 bash -c "cd driver && docker build -t session-segmenter-driver ."

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
 
-sbt ";app/docker:publishLocal; driver/docker:publishLocal; reader/docker:publishLocal"
+docker run -it --rm -v $(pwd):/root hseeberger/scala-sbt sh ./build-project.sh
+#docker run -it --rm -v $(pwd):/user hseeberger/scala-sbt cd /user && sbt compile assembly
+if [[ $? -eq 0 ]]
+then 
+bash -c "cd driver && docker build -t session-segmenter-driver ."
+bash -c "cd app && docker build -t session-segmenter-app ."
+bash -c "cd reader && docker build -t session-segmenter-reader ."
+else
+  exit 1
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
 
   app:
-    image: session-segmenter:1
+    image: session-segmenter-app:latest
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_SCHEMA_REGISTRY: "http://schema-registry:8081"
@@ -11,7 +11,7 @@ services:
       - schema-registry
 
   driver:
-    image: session-segmenter-driver:1
+    image: session-segmenter-driver:latest
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_SCHEMA_REGISTRY: "http://schema-registry:8081"
@@ -21,7 +21,7 @@ services:
       - schema-registry
 
   reader:
-    image: session-segmenter-reader:1
+    image: session-segmenter-reader:latest
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_SCHEMA_REGISTRY: "http://schema-registry:8081"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
 
   app:
-    image: session-segmenter-app:1
+    image: session-segmenter:1
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_SCHEMA_REGISTRY: "http://schema-registry:8081"
@@ -55,7 +55,6 @@ services:
   schema-registry:
     image: confluentinc/cp-schema-registry:5.0.1
     hostname: schema-registry
-    container_name: schema-registry
     depends_on:
       - zookeeper
       - kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
 
   app:
-    image: session-segmenter-app:latest
+    image: session-segmenter-app:1
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_SCHEMA_REGISTRY: "http://schema-registry:8081"
@@ -11,7 +11,7 @@ services:
       - schema-registry
 
   driver:
-    image: session-segmenter-driver:latest
+    image: session-segmenter-driver:1
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_SCHEMA_REGISTRY: "http://schema-registry:8081"
@@ -21,7 +21,7 @@ services:
       - schema-registry
 
   reader:
-    image: session-segmenter-reader:latest
+    image: session-segmenter-reader:1
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_SCHEMA_REGISTRY: "http://schema-registry:8081"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '2.1'
 services:
-
   app:
     image: session-segmenter:1
     environment:
@@ -55,6 +54,7 @@ services:
   schema-registry:
     image: confluentinc/cp-schema-registry:5.0.1
     hostname: schema-registry
+    container_name: schema-registry
     depends_on:
       - zookeeper
       - kafka

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8-jre-alpine
+WORKDIR /opt/docker
+ADD --chown=daemon:daemon target/scala-2.12/ /opt/docker
+USER daemon
+ENTRYPOINT ["java", "-jar", "driver-assembly-1.jar" ]
+CMD []
+

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")

--- a/reader/Dockerfile
+++ b/reader/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8-jre-alpine
+WORKDIR /opt/docker
+ADD --chown=daemon:daemon target/scala-2.12/ /opt/docker
+USER daemon
+ENTRYPOINT ["java", "-jar", "reader-assembly-1.jar" ]
+CMD []
+


### PR DESCRIPTION
this build tries to improve the demo-segmenter build
- has no requirements for sbt or java on host environment using docker scala-sbt
- use openjdk:8-alpine jre image instead of jdk which reduces runtime image
potential problems
- workaround to avoid root folder creation of .sbt and .ivy2 is using UID 1000 which may not work in all environments